### PR TITLE
Add all struct changes for delete and create changes

### DIFF
--- a/diff/diff_struct.go
+++ b/diff/diff_struct.go
@@ -57,7 +57,11 @@ func (d *differ) diffStruct(x, y cue.Value) (bool, error) {
 			if xf.IsHidden && d.cfg.IgnoreHiddenFields {
 				continue
 			}
-			d.cl.Add(DELETE, xv.Path(), &xv, nil)
+			// Add subfields to the changelog as well
+			xv.Walk(func(v cue.Value) bool {
+				d.cl.Add(DELETE, v.Path(), &v, nil)
+				return true
+			}, nil)
 			hasDiff = true
 		}
 		for ; yi < sy.Len(); yi++ {
@@ -78,7 +82,11 @@ func (d *differ) diffStruct(x, y cue.Value) (bool, error) {
 			if yf.IsHidden && d.cfg.IgnoreHiddenFields {
 				continue
 			}
-			d.cl.Add(CREATE, yv.Path(), nil, &yv)
+			// Add subfields to the changelog as well
+			yv.Walk(func(v cue.Value) bool {
+				d.cl.Add(CREATE, v.Path(), nil, &v)
+				return true
+			}, nil)
 			hasDiff = true
 		}
 


### PR DESCRIPTION
When a struct is added or removed, add to the changelog all
sub fields of the struct.